### PR TITLE
update combinatorics, drop 0.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
   - 0.6
   - nightly

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 A package for factoring polynomials with integer or rational coefficients over the integers.
 
-[![PolynomialFactors](http://pkg.julialang.org/badges/PolynomialFactors_0.4.svg)](http://pkg.julialang.org/?pkg=PolynomialFactors&ver=0.4)
 [![PolynomialFactors](http://pkg.julialang.org/badges/PolynomialFactors_0.5.svg)](http://pkg.julialang.org/?pkg=PolynomialFactors&ver=0.5)
 [![PolynomialFactors](http://pkg.julialang.org/badges/PolynomialFactors_0.6.svg)](http://pkg.julialang.org/?pkg=PolynomialFactors&ver=0.6)
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
 Polynomials 0.1.1
 Compat 0.17.0
-Combinatorics 0.2.1
+Combinatorics 0.4.1
 Primes 0.1.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"


### PR DESCRIPTION
avoids possible issue with non-upgraded combinatorics package having trouble with rename of iterators when precompiling